### PR TITLE
 README Typos: Correct "Ommitting" and "exetutables" to "Omitting and executables"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Multiple streamlit apps based on the [OpenMS streamlit template](https://github.
 
 **2. Specify GitHub token (to download Windows executables).**
 
-> This is **important**! Ommitting this step while result in all apps not having the option to download exetutables any more.
+> This is **important**! Omitting this step while result in all apps not having the option to download executables any more.
 
 Create a temporary `.env` file with your Github token. It should contain only one line:
 


### PR DESCRIPTION
Issue Description:
While reviewing the documentation, I noticed two typos in the README that could confuse contributors and users:

1. The word "Ommitting" should be corrected to "Omitting".

2. The word "exetutables" should be corrected to "executables".

Fixing these typos will improve the clarity and professionalism of the repository's documentation. I propose updating the README accordingly, ensuring consistency and better readability for new contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and professionalism by correcting spelling errors in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->